### PR TITLE
Added proper parsing of responses

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,15 +3,15 @@ asyncio_mode = auto
 log_cli = True
 log_cli_level = INFO
 
-#addopts =
-#    --strict-markers
-#    --pdbcls=tests:Debugger
-#
-#    -r sxX
-#
-#    --cov-report=html
-#    --cov-report=term-missing:skip-covered
-#    --no-cov-on-fail
+addopts =
+    --strict-markers
+    --pdbcls=tests:Debugger
+
+    -r sxX
+
+    --cov-report=html
+    --cov-report=term-missing:skip-covered
+    --no-cov-on-fail
 
 cache_dir = .cache
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,14 +1,17 @@
 [pytest]
+asyncio_mode = auto
+log_cli = True
+log_cli_level = INFO
 
-addopts =
-    --strict-markers
-    --pdbcls=tests:Debugger
-
-    -r sxX
-
-    --cov-report=html
-    --cov-report=term-missing:skip-covered
-    --no-cov-on-fail
+#addopts =
+#    --strict-markers
+#    --pdbcls=tests:Debugger
+#
+#    -r sxX
+#
+#    --cov-report=html
+#    --cov-report=term-missing:skip-covered
+#    --no-cov-on-fail
 
 cache_dir = .cache
 

--- a/skydance/protocol.py
+++ b/skydance/protocol.py
@@ -22,6 +22,7 @@ _COMMAND_MAGIC = bytes.fromhex("80 00 80 e1 80 00 00")
 
 DEVICE_BASE_TYPE_NORMAL = 0x80
 
+
 class State:
     """Holds state of a connection."""
 
@@ -382,26 +383,28 @@ class Response(metaclass=ABCMeta):
         lbody = self.body
         li = 0
 
-        self.device_type = lbody[li: li + 3]
+        self.device_type = lbody[li : li + 3]
         li += 3
 
-        self.src_addr = struct.unpack("<H", lbody[li: li + 2])[0]
+        self.src_addr = struct.unpack("<H", lbody[li : li + 2])[0]
         li += 2
 
-        self.dst_addr = struct.unpack("<H", lbody[li: li + 2])[0]
-        li += 2 
-
-        self.zone = struct.unpack("<H", lbody[li: li + 2])[0]
+        self.dst_addr = struct.unpack("<H", lbody[li : li + 2])[0]
         li += 2
 
-        self.cmd_type = struct.unpack("B", lbody[li: li + 1])[0] - DEVICE_BASE_TYPE_NORMAL
+        self.zone = struct.unpack("<H", lbody[li : li + 2])[0]
+        li += 2
+
+        self.cmd_type = (
+            struct.unpack("B", lbody[li : li + 1])[0] - DEVICE_BASE_TYPE_NORMAL
+        )
         li += 1
 
-        cmd_data_lenght = struct.unpack("<H", lbody[li: li + 2])[0]
+        cmd_data_lenght = struct.unpack("<H", lbody[li : li + 2])[0]
         li += 2
 
         if cmd_data_lenght > 0:
-            self.cmd_data = lbody[li: li + cmd_data_lenght]
+            self.cmd_data = lbody[li : li + cmd_data_lenght]
             li += cmd_data_lenght
 
     @property
@@ -440,19 +443,19 @@ class GetNumberOfZonesResponse(Response):
 
         for lbyte in self.cmd_data:
             if (lbyte & DEVICE_BASE_TYPE_NORMAL) == DEVICE_BASE_TYPE_NORMAL:
-                zoneId = lbyte & 0x1f
+                zoneId = lbyte & 0x1F
                 self._zones.append(zoneId)
-
 
     @property
     def number(self) -> int:
-    """Return number of zones available."""
+        """Return number of zones available."""
         return len(self._zones)
 
     @property
     def zones(self) -> list:
-    """Return list of IDs of zones available."""
+        """Return list of IDs of zones available."""
         return self._zones
+
 
 class GetZoneInfoResponse(Response):
     """

--- a/skydance/protocol.py
+++ b/skydance/protocol.py
@@ -385,7 +385,7 @@ class Response(metaclass=ABCMeta):
         self.device_type = lbody[li: li + 3]
         li += 3
 
-        self.scr_addr = struct.unpack("<H", lbody[li: li + 2])[0]
+        self.src_addr = struct.unpack("<H", lbody[li: li + 2])[0]
         li += 2
 
         self.dst_addr = struct.unpack("<H", lbody[li: li + 2])[0]
@@ -446,10 +446,12 @@ class GetNumberOfZonesResponse(Response):
 
     @property
     def number(self) -> int:
+    """Return number of zones available."""
         return len(self._zones)
 
     @property
     def zones(self) -> list:
+    """Return list of IDs of zones available."""
         return self._zones
 
 class GetZoneInfoResponse(Response):

--- a/tests/test_manual.py
+++ b/tests/test_manual.py
@@ -67,7 +67,7 @@ async def test_state_frame_number_overflow(state, session):
 
 
 @pytest.mark.asyncio
-async def test_zone_discovery(state, session, caplog):
+async def test_zone_discovery(state, session):
     log.info("Getting number of zones")
     cmd = GetNumberOfZonesCommand(state).raw
     await session.write(cmd)

--- a/tests/test_manual.py
+++ b/tests/test_manual.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.skipif(
     "attached to the local network.",
 )
 
-IP = os.getenv("IP", default="192.168.2.30")
+IP = os.getenv("IP", default="192.168.88.113")
 IP_BROADCAST = "192.168.3.255"
 
 log = logging.getLogger(__name__)
@@ -31,7 +31,6 @@ def state_fixture():
 async def session_fixture():
     async with Session(IP, PORT) as session:
         yield session
-
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -68,15 +67,14 @@ async def test_state_frame_number_overflow(state, session):
 
 
 @pytest.mark.asyncio
-async def test_zone_discovery(state, session):
+async def test_zone_discovery(state, session, caplog):
     log.info("Getting number of zones")
     cmd = GetNumberOfZonesCommand(state).raw
     await session.write(cmd)
     state.increment_frame_number()
     res = await session.read(64)
-    number_of_zones = GetNumberOfZonesResponse(res).number
 
-    for zone in range(1, number_of_zones + 1):
+    for zone in GetNumberOfZonesResponse(res).zones:
         log.info("Getting info about zone=%d", zone)
         cmd = GetZoneInfoCommand(state, zone=zone).raw
         await session.write(cmd)

--- a/tests/test_manual.py
+++ b/tests/test_manual.py
@@ -32,6 +32,7 @@ async def session_fixture():
     async with Session(IP, PORT) as session:
         yield session
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "chunk_size", range(1, 41)


### PR DESCRIPTION
As a result of this patch `GetNumberOfZonesResponse` begins work properly, and doesn't report zones that not exist on wifi controller

Decompiled code looks like this(code below for example purposes)
```java
    public Cmd fromByteArray(byte[] bArr) {
        SkyDanceCmd skyDanceCmd = new SkyDanceCmd();
        skyDanceCmd.frameNumber = ByteUtil2.byteToInt(bArr[5]);
        System.arraycopy(bArr, 6, skyDanceCmd.deviceType, 0, 3);
        System.arraycopy(bArr, 11, SkyDanceCmd.desAddress, 0, 2);
        byte[] bArr2 = new byte[2];
        System.arraycopy(bArr, 13, bArr2, 0, 2);
        int i = 0;
        while (true) {
            if (i >= 16) {
                break;
            }
            byte[] intToByteArray2 = ByteUtil2.intToByteArray2((int) Math.pow(2.0d, (double) i)); // it's just a binary shift(1 << i) apparently there are 16 possible zones, and each zone is a bit
            if (bArr2[0] == intToByteArray2[0] && bArr2[1] == intToByteArray2[1]) {
                skyDanceCmd.zome = i + 1;
                break;
            }
            i++;
        }
        skyDanceCmd.cmdType = bArr[15]; // the type of command itself
        byte[] cmdLengthArr = new byte[2];
        System.arraycopy(bArr, 16, cmdLengthArr, 0, 2);
        skyDanceCmd.cmdLength = ByteUtil2.byte2Toint(cmdLengthArr);
        if (skyDanceCmd.cmdLength > 0) {
            skyDanceCmd.cmdData = new byte[skyDanceCmd.cmdLength];
            System.arraycopy(bArr, 18, skyDanceCmd.cmdData, 0, skyDanceCmd.cmdLength);
        }
        skyDanceCmd.crcValue = bArr[skyDanceCmd.cmdLength + 18];
        return skyDanceCmd;
    }

```

Here is pice of code that parses response from wifi controller on `0x79(CMD_CONTROLLER_NUMBER_AND_NAME_QUERY)` command - in this library it is `GetNumberOfZonesCommand`  

```java
            if (b2 == SkyDanceCmdContants.CMD_CONTROLLER_NUMBER_AND_NAME_QUERY) { // polling the number of monitored devices (without parameters)
                this.controllerNumberAndNameQueryIsSuccess = true;
                this.subDevices.clear();
                for (byte b3 : skyDanceCmd.cmdData) {
                    if ((b3 & 0xff & DeviceBaseType.DEVICE_BASE_TYPE_NORMAL) == 0x80 && (b = b3 & 0x1f) > 0) {
                        SkyDanceDeviceInfo skyDanceDeviceInfo = new SkyDanceDeviceInfo();
                        skyDanceDeviceInfo.f76ip = getIp();
                        skyDanceDeviceInfo.deviceType = getDeviceInfo().deviceType;
                        skyDanceDeviceInfo.zoneId = b;
                        SkyDanceController skyDanceController = new SkyDanceController(skyDanceDeviceInfo);
                        skyDanceController.targetZomeId = b;
                        skyDanceController.deviceInfo = skyDanceDeviceInfo;
                        skyDanceController.f60ip = skyDanceDeviceInfo.f76ip;
                        skyDanceController.setDeviceInfo(skyDanceDeviceInfo);
                        this.subDevices.add(skyDanceController);
                    }
                }
                EventBus.getDefault().post(skyDanceCmd.cmdData);
                int size = this.subDevices.size();
                for (int i = 0; i < size; i++) {
                    Log.d("wifirelayquery", "dt=" + ByteUtil2.bytesToHex(((SkyDanceController) this.subDevices.get(i)).getDeviceInfo().deviceType));
                }
            }
```