### PR TITLE
Pin Poetry version to 2.2.1 in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
       
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 2.2.1
 
       - name: Cache dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
This change pins the Poetry installation to a specific version (2.2.1) in the CI workflow to ensure consistent and reproducible builds across all environments.

## Key Changes
- Added explicit `version: 2.2.1` parameter to the `snok/install-poetry@v1` action in the CI workflow

## Details
Previously, the Poetry installation step did not specify a version, which could result in different Poetry versions being installed on different CI runs. By pinning to version 2.2.1, we ensure that all CI jobs use the same Poetry version, improving build reproducibility and reducing the risk of unexpected behavior changes due to Poetry version differences.

https://claude.ai/code/session_01UsX7expEua8kDwtuP6MBCh